### PR TITLE
main: Delete TCPIP_MODE_EXIT

### DIFF
--- a/include/mode.h
+++ b/include/mode.h
@@ -2,7 +2,7 @@
 #define MODE_H
 
 enum tcpip_mode {
-	TCPIP_MODE_EXIT,
+	TCPIP_MODE_DUMMY,
 	TCPIP_MODE_RECV,
 	TCPIP_MODE_SEND,
 };

--- a/src/main.c
+++ b/src/main.c
@@ -12,8 +12,7 @@ int main()
 		enum tcpip_mode mode;
 
 		printf("===========================\n"
-			"Select Mode\n"
-			"0. Exit\n"
+			"Select Mode (Exit: Ctrl+C)\n"
 			"1. Receiver Mode\n"
 			"2. Sender Mode\n"
 			"===========================\n"
@@ -26,8 +25,6 @@ int main()
 
 		mode = atoi(input);
 		switch (mode) {
-		case TCPIP_MODE_EXIT:
-			return 0;
 		case TCPIP_MODE_RECV:
 			start_recv_mode();
 			break;
@@ -35,6 +32,7 @@ int main()
 			start_send_mode();
 			break;
 		default:
+			printf("Wrong number\n");
 			break;
 		}
 		printf("\n");


### PR DESCRIPTION
"EXIT" is not a valid mode for this program.
Remove TCPIP_MODE_EXIT from the tcpip_mode enum and its handling in main().

To exit the program, users can simply press Ctrl+C.