### PR TITLE
ethernet: Parse ethernet header from received packet

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -1,4 +1,25 @@
+/* SPDX-License-Identifier: MIT */
+
 #ifndef ETHERNET_H
 #define ETHERNET_H
+
+#include <linux/types.h>
+
+#include "packet.h"
+
+#define MAC_LEN 6
+
+struct eth_hdr {
+	unsigned char	dst_mac[MAC_LEN];
+	unsigned char	src_max[MAC_LEN];
+	__be16		type;
+} __attribute__((packed));
+
+void eth_recv(struct packet *pkt);
+
+static inline struct eth_hdr *get_eth_hdr(struct packet *pkt)
+{
+	return (struct eth_hdr *)pkt_get_mac_header(pkt);
+}
 
 #endif

--- a/include/net/packet.h
+++ b/include/net/packet.h
@@ -5,14 +5,31 @@
 
 #define PKT_SIZE 2048
 
-#include <sys/types.h>
+#include <linux/types.h>
 
 struct packet {
-	unsigned char data[PKT_SIZE];
-	int len;
-	int recv_ifindex;
+	unsigned char	data[PKT_SIZE];
+
+	int		recv_ifindex; /* Received network interface index */
+	int		len;
+
+	/* Offset from data[0] to each layer header */
+	__u16		mac_header;
+	__u16		network_header;
+	__u16		transport_header;
 };
 
-void handle_packet(struct packet *pkt);
+void handle_recv_packet(struct packet *pkt);
+
+static inline unsigned char *pkt_get_mac_header(struct packet *pkt)
+{
+	return pkt->data + pkt->mac_header;
+}
+
+static inline unsigned char *pkt_set_mac_header(struct packet *pkt,
+						const int offset)
+{
+	return pkt->data + offset;
+}
 
 #endif

--- a/src/core/recv_thread.c
+++ b/src/core/recv_thread.c
@@ -53,7 +53,7 @@ void *recv_thread(void *arg)
 
 				pkt->recv_ifindex = sa.sll_ifindex;
 
-				handle_packet(pkt);
+				handle_recv_packet(pkt);
 				free(pkt);
 			} else if (events[i].data.fd == rti.terminate_fd) {
 				pthread_exit(0);

--- a/src/net/ethernet.c
+++ b/src/net/ethernet.c
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <linux/if_ether.h>
+#include <arpa/inet.h>
+
+#include "ethernet.h"
+
+void eth_recv(struct packet *pkt)
+{
+	struct eth_hdr *eth;
+
+	pkt_set_mac_header(pkt, 0);
+	eth = get_eth_hdr(pkt);
+
+	switch (ntohs(eth->type)) {
+	case ETH_P_ARP:
+		/* Todo: Call arp_handler */
+		printf("ARP packet received\n"); /* test code */
+		break;
+	case ETH_P_IP:
+		/* Todo: Call ip_handler */
+		printf("IP packet received\n"); /* test code */
+		break;
+	default:
+		break;
+	}
+}

--- a/src/net/packet.c
+++ b/src/net/packet.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-#include <stdio.h>
 #include "packet.h"
+#include "ethernet.h"
 
-void handle_packet(struct packet *pkt)
+void handle_recv_packet(struct packet *pkt)
 {
-	(void)pkt; /* dummy code */
+	eth_recv(pkt);
 }


### PR DESCRIPTION
The packet structure stores overall packet information.
The eth_hdr structure stores ethernet header fields of packet.
eth_recv() parses the Ethernet header and calls the appropriate upper-layer handler function.